### PR TITLE
Better errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ interfax.deliver({
 })
 .catch(error => {
   console.log(error);
-  //=> an error object
+  //=> an error object with a status code,
+  //=> description and the body
 });
 ```
 
@@ -50,7 +51,8 @@ interfax.deliver({
 }, function(error, response) {
   if (error) {
     console.log(error);
-    //=> an error object
+    //=> an error object with a status code,
+    //=> description and the body
   } else {
     console.log(response.id);
     //=> the ID of the Fax just created
@@ -60,7 +62,7 @@ interfax.deliver({
 
 # Usage
 
-[Client](#client) | [Account](#account) | [Outbound](#outbound) | [Inbound](#inbound) | [Documents](#documents) | [Files](#files)
+[Client](#client) | [Account](#account) | [Outbound](#outbound) | [Inbound](#inbound) | [Documents](#documents) | [Files](#files) | [Errrors](#errors)
 
 ## Client
 
@@ -533,6 +535,19 @@ interfax.files.create('foo/bar.pdf');
 // a file by url
 interfax.files.create('https://foo.com/bar.html');
 ```
+
+## Errors
+
+In case of any error the error object will wrap the HTTP status code, the body, and a handy description in one object. More details on the exact error objects can be found [on the reference documentation](https://www.interfax.net/en/node/10606).
+
+```js
+{
+  status: 200,
+  body: null,
+  description: 'Connection closed by peer'
+}
+```
+
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interfax",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A wrapper around the InterFAX REST API for sending and receiving faxes.",
   "main": "lib/interfax.js",
   "scripts": {

--- a/src/response-handler.js
+++ b/src/response-handler.js
@@ -27,14 +27,22 @@ class ResponseHandler {
         else if (isJson && result.length == 0) { result = null; }
 
         if (response.statusCode >= 300) {
-          emitter.emit('reject', result);
+          emitter.emit('reject', {
+            status: response.statusCode,
+            body: result,
+            description: `Unexpected HTTP status code: ${response.statusCode}`
+          });
         } else {
           emitter.emit('resolve', result);
         }
       });
 
       response.on('close', function(error) {
-        emitter.emit('reject', error);
+        emitter.emit('reject', {
+          status: response.statusCode,
+          body: error,
+          description: 'Connection closed by peer'
+        });
       });
     };
   }


### PR DESCRIPTION
Currently, if the user receives a 429 error it does not actually throw a useful error at all. I've been wondering how to deal with this as the body has no useful content. This is a simple attempt.