### PR TITLE
Fix files create bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,12 +146,13 @@ Additionally you can create a [`File`](#files) with binary data and pass this in
 
 ```js
 let data = fs.readFileSync('fax.pdf');
-let file = interfax.files.create(data, {mimeType: 'application/pdf'});
-
-interfax.outbound.deliver({
-  faxNumber: "+11111111112",
-  file: file
-}).then(...);
+interfax.files.create(data, {mimeType: 'application/pdf'})
+  .then(function(file) {
+    interfax.outbound.deliver({
+      faxNumber: "+11111111112",
+      file: file
+    });
+  });
 ```
 
 To send multiple files just pass in an array of strings and [`File`](#files) objects.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interfax",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A wrapper around the InterFAX REST API for sending and receiving faxes.",
   "main": "lib/interfax.js",
   "scripts": {

--- a/src/interfax.js
+++ b/src/interfax.js
@@ -22,8 +22,7 @@ class InterFAX {
 
     this.account   = new Account(this._client);
     this.inbound   = new Inbound(this._client);
-    this.files     = new Files(this._client, this.documents);
-
+    this.files     = new Files(this.documents);
   }
 }
 

--- a/tests/interfax.js
+++ b/tests/interfax.js
@@ -4,6 +4,8 @@ import Client       from '../src/client.js';
 import Outbound     from '../src/outbound.js';
 import Inbound      from '../src/inbound.js';
 import Delivery     from '../src/delivery.js';
+import Files        from '../src/files.js';
+import Documents    from '../src/documents.js';
 
 import { expect } from 'chai';
 
@@ -47,6 +49,11 @@ describe('InterFAX', () => {
 
     it('should initialise the Inbound client', () => {
       expect(interfax.inbound).to.be.an.instanceof(Inbound);
+    });
+
+    it('should initialise the Files client', () => {
+      expect(interfax.files).to.be.an.instanceof(Files);
+      expect(interfax.files._documents).to.be.an.instanceof(Documents);
     });
   });
 });


### PR DESCRIPTION
Closes #5 

Fixed bug with file creation for large files. The Files class was passed a Client instance instead of a Documents instance. Code fixed and tests added.

Documentation had an error as well, as it didn't use promises.