### PR TITLE
Add hide function to outbound class.

### DIFF
--- a/src/outbound.js
+++ b/src/outbound.js
@@ -31,6 +31,10 @@ class Outbound {
   search(params, callback) {
     return this._client.get('/outbound/search', params, callback);
   }
+  
+  hide(id, callback) {
+    return this._client.post(`/outbound/faxes/${id}/hide`, callback);
+  }
 }
 
 export default Outbound;


### PR DESCRIPTION
Outbound misses the api call to hide a fax. 

Here is the documentation:
https://www.interfax.net/de/node/10615